### PR TITLE
Provision an Opsee role outside of the Cloudformation stack

### DIFF
--- a/etc/bastion-cf.template
+++ b/etc/bastion-cf.template
@@ -41,6 +41,10 @@
         "CustomerId": {
             "Description": "Customer ID",
             "Type": "String"
+        },
+        "BastionId": {
+            "Description": "Bastion ID",
+            "Type": "String"
         }
     },
     "Conditions": {
@@ -67,97 +71,6 @@
         }
     },
     "Resources": {
-        "OpseeRole": {
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [{
-                        "Effect": "Allow",
-                        "Principal": {
-                            "AWS": "933693344490"
-                        },
-                        "Action": "sts:AssumeRole",
-                        "Condition": {
-                            "StringEquals": {
-                                "sts:ExternalId": {
-                                    "Ref": "CustomerId"
-                                }
-                            }
-                        }
-                    }, {
-                        "Effect": "Allow",
-                        "Principal": {
-                            "Service": ["ec2.amazonaws.com"]
-                        },
-                        "Action": ["sts:AssumeRole"]
-                    }]
-                },
-                "Path": "/",
-                "Policies": [{
-                    "PolicyName": "OpseePolicy",
-                    "PolicyDocument": {
-                        "Version": "2012-10-17",
-                        "Statement": [{
-                            "Effect": "Allow",
-                            "Action": [
-                                "autoscaling:DescribeLoadBalancers",
-                                "autoscaling:DescribeAutoScalingGroups",
-                                "cloudformation:CreateStack",
-                                "cloudformation:DeleteStack",
-                                "cloudformation:ListStackResources",
-                                "ec2:CreateTags",
-                                "ec2:DeleteTags",
-                                "ec2:AuthorizeSecurityGroupIngress",
-                                "ec2:AuthorizeSecurityGroupEgress",
-                                "ec2:RevokeSecurityGroupIngress",
-                                "ec2:RevokeSecurityGroupEgress",
-                                "ec2:StartInstances",
-                                "ec2:RunInstances",
-                                "ec2:StopInstances",
-                                "ec2:RebootInstances",
-                                "ec2:TerminateInstances",
-                                "ec2:DescribeAccountAttributes",
-                                "ec2:DescribeImages",
-                                "ec2:DescribeSecurityGroups",
-                                "ec2:CreateSecurityGroup",
-                                "ec2:DeleteSecurityGroup",
-                                "ec2:DescribeSubnets",
-                                "ec2:DescribeVpcs",
-                                "ec2:DescribeInstances",
-                                "ec2:DescribeInternetGateways",
-                                "ec2:DescribeRouteTables",
-                                "elasticloadbalancing:DescribeLoadBalancers",
-                                "iam:AddRoleToInstanceProfile",
-                                "iam:RemoveRoleFromInstanceProfile",
-                                "iam:CreateRole",
-                                "iam:CreateRolePolicy",
-                                "iam:CreateInstanceProfile",
-                                "iam:PutRolePolicy",
-                                "iam:DeleteRole",
-                                "iam:DeleteRolePolicy",
-                                "iam:DeleteInstanceProfile",
-                                "iam:PassRole",
-                                "sns:CreateTopic",
-                                "sns:DeleteTopic",
-                                "sns:Subscribe",
-                                "sns:Unsubscribe",
-                                "sns:Publish",
-                                "sqs:CreateQueue",
-                                "sqs:DeleteQueue",
-                                "sqs:DeleteMessage",
-                                "sqs:ReceiveMessage",
-                                "sqs:GetQueueAttributes",
-                                "sqs:SetQueueAttributes",
-                                "rds:DescribeDBInstances",
-                                "rds:DescribeDBSecurityGroups"
-                            ],
-                            "Resource": "*"
-                        }]
-                    }
-                }]
-            }
-        },
         "OpseeSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
             "Properties": {
@@ -166,8 +79,11 @@
                     "Key": "Name",
                     "Value": "Opsee Instance Security Group"
                 }, {
-                    "Key": "type",
-                    "Value": "opsee"
+                    "Key": "vendor",
+                    "Value": "Opsee"
+                }, {
+                    "Key": "opsee:customer-id",
+                    "Value": {"Ref": "CustomerId"}
                 }],
                 "SecurityGroupEgress": [{
                     "CidrIp": "0.0.0.0/0",
@@ -190,14 +106,25 @@
             "Type": "AWS::IAM::InstanceProfile",
             "Properties": {
                 "Path": "/",
-                "Roles": [{
-                    "Ref": "OpseeRole"
-                }]
+                "Roles": ["OpseeRole"]
             }
         },
         "OpseeInstance": {
             "Type": "AWS::EC2::Instance",
             "Properties": {
+                "Tags": [{
+                    "Key": "Name",
+                    "Value": "Opsee Instance"
+                }, {
+                    "Key": "vendor",
+                    "Value": "Opsee"
+                }, {
+                    "Key": "opsee:id",
+                    "Value": {"Ref": "BastionId"}
+                }, {
+                    "Key": "opsee:customer-id",
+                    "Value": {"Ref": "CustomerId"}
+                }],
                 "ImageId": {
                     "Ref": "ImageId"
                 },

--- a/src/github.com/opsee/keelhaul/launcher/launcher.go
+++ b/src/github.com/opsee/keelhaul/launcher/launcher.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	etcd "github.com/coreos/etcd/client"
 	"github.com/opsee/basic/com"
+	"github.com/opsee/basic/spanx"
 	"github.com/opsee/keelhaul/bus"
 	"github.com/opsee/keelhaul/config"
 	"github.com/opsee/keelhaul/router"
@@ -19,6 +20,7 @@ type launcher struct {
 	etcd   etcd.KeysAPI
 	bus    bus.Bus
 	router router.Router
+	spanx  spanx.Client
 	config *config.Config
 }
 
@@ -28,12 +30,13 @@ func New(db store.Store, router router.Router, etcdKAPI etcd.KeysAPI, bus bus.Bu
 		router: router,
 		etcd:   etcdKAPI,
 		bus:    bus,
+		spanx:  spanx.New(cfg.SpanxEndpoint),
 		config: cfg,
 	}
 }
 
 func (l *launcher) LaunchBastion(sess *session.Session, user *com.User, vpcID, subnetID, subnetRouting, instanceType string) (*Launch, error) {
-	launch := NewLaunch(l.db, l.router, l.etcd, l.config, sess, user)
+	launch := NewLaunch(l.db, l.router, l.etcd, l.spanx, l.config, sess, user)
 	go l.watchLaunch(launch)
 
 	// this is done synchronously so that we can return the bastion id

--- a/src/github.com/opsee/keelhaul/launcher/stage_cloudformation.go
+++ b/src/github.com/opsee/keelhaul/launcher/stage_cloudformation.go
@@ -348,6 +348,10 @@ func (s createStack) Execute(launch *Launch) {
 			ParameterKey:   aws.String("CustomerId"),
 			ParameterValue: aws.String(launch.User.CustomerID),
 		},
+		{
+			ParameterKey:   aws.String("BastionId"),
+			ParameterValue: aws.String(launch.Bastion.ID),
+		},
 	}
 
 	stack, err := launch.cloudformationClient.CreateStack(&cloudformation.CreateStackInput{
@@ -360,7 +364,15 @@ func (s createStack) Execute(launch *Launch) {
 		Tags: []*cloudformation.Tag{
 			{
 				Key:   aws.String("Name"),
-				Value: aws.String("Opsee Stack " + launch.User.CustomerID),
+				Value: aws.String("Opsee Stack"),
+			},
+			{
+				Key:   aws.String("vendor"),
+				Value: aws.String("Opsee"),
+			},
+			{
+				Key:   aws.String("opsee:customer-id"),
+				Value: aws.String(launch.User.CustomerID),
 			},
 		},
 		NotificationARNs: []*string{

--- a/src/github.com/opsee/keelhaul/launcher/stage_role.go
+++ b/src/github.com/opsee/keelhaul/launcher/stage_role.go
@@ -1,0 +1,92 @@
+package launcher
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/cenkalti/backoff"
+	"github.com/opsee/basic/com"
+	"time"
+)
+
+type putRole struct{}
+
+func (s putRole) Execute(launch *Launch) {
+	credValue, err := launch.session.Config.Credentials.Get()
+	if err != nil {
+		launch.error(
+			err,
+			&com.Message{
+				Command: commandLaunchBastion,
+				Message: "error fetching credentials from session",
+			},
+		)
+
+		return
+	}
+
+	stscreds, err := launch.spanx.PutRole(launch.User, credValue.AccessKeyID, credValue.SecretAccessKey)
+	if err != nil {
+		launch.error(
+			err,
+			&com.Message{
+				Command: commandLaunchBastion,
+				Message: "error provisioning opsee role",
+			},
+		)
+
+		return
+	}
+
+	// test to see if our role is actually usable by doing something with it
+	ec2Client := ec2.New(
+		launch.session.Copy(&aws.Config{
+			Credentials: credentials.NewStaticCredentials(
+				stscreds.AccessKeyID,
+				stscreds.SecretAccessKey,
+				stscreds.SessionToken,
+			),
+		}),
+	)
+
+	err = backoff.Retry(func() error {
+		_, err = ec2Client.DescribeVpcs(nil)
+		if err != nil {
+			return err
+		}
+
+		return nil
+
+	}, &backoff.ExponentialBackOff{
+		InitialInterval:     100 * time.Millisecond,
+		RandomizationFactor: 0.5,
+		Multiplier:          1.5,
+		MaxInterval:         time.Second,
+		MaxElapsedTime:      5 * time.Second,
+		Clock:               &systemClock{},
+	})
+
+	if err != nil {
+		launch.error(
+			err,
+			&com.Message{
+				Command: commandLaunchBastion,
+				Message: "error using new opsee provisioned role",
+			},
+		)
+
+		return
+	}
+
+	launch.event(&com.Message{
+		State:   stateInProgress,
+		Command: commandLaunchBastion,
+		Message: "created global opsee role",
+	})
+}
+
+type systemClock struct{}
+
+func (s *systemClock) Now() time.Time {
+	return time.Now()
+}

--- a/src/github.com/opsee/keelhaul/service/service.go
+++ b/src/github.com/opsee/keelhaul/service/service.go
@@ -3,7 +3,6 @@ package service
 import (
 	"errors"
 	"github.com/opsee/basic/com"
-	"github.com/opsee/basic/spanx"
 	"github.com/opsee/keelhaul/bus"
 	"github.com/opsee/keelhaul/config"
 	"github.com/opsee/keelhaul/launcher"
@@ -57,7 +56,6 @@ type service struct {
 	launcher launcher.Launcher
 	bus      bus.Bus
 	router   router.Router
-	spanx    spanx.Client
 	config   *config.Config
 }
 
@@ -67,7 +65,6 @@ func New(db store.Store, bus bus.Bus, launch launcher.Launcher, router router.Ro
 		launcher: launch,
 		bus:      bus,
 		router:   router,
-		spanx:    spanx.New(cfg.SpanxEndpoint),
 		config:   cfg,
 	}
 }


### PR DESCRIPTION
- CF stacks will now have the opsee-stack-CUSTID name, so now only one bastion/security group will be allowed per aws account/customer/region
- we now provision a global opsee role used by the bastion and our backend with cross-account permissions, named OpseeRole
- the bastion will now be tagged with the name "Opsee Instance"
- the security group will now be tagged with the name "Opsee Instance Security Group"
- the bastion, CF stack, and security group are tagged with more metadata: "vendor:Opsee opsee:customer-id:abcd-dead-beef"
